### PR TITLE
修复bug

### DIFF
--- a/library/src/main/java/com/allenliu/versionchecklib/core/VersionDialogActivity.java
+++ b/library/src/main/java/com/allenliu/versionchecklib/core/VersionDialogActivity.java
@@ -228,6 +228,11 @@ public class VersionDialogActivity extends AllenBaseActivity implements Download
 
 
     protected void requestPermissionAndDownloadFile() {
+        // if dir is writable, skip checking permission
+        if (new File(versionParams.getDownloadAPKPath()).canWrite()) {
+            Log.i(TAG, "requestPermissionAndDownloadFile: " + new File(versionParams.getDownloadAPKPath()).canWrite());
+            downloadFile();
+        } else
         // Here, thisActivity is the current activity
         if (ContextCompat.checkSelfPermission(this,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE)


### PR DESCRIPTION
当设置了强制更新时, 如果没有授予外部文件读写权限, 则会跳过更新
解决方法: 检查权限之前判断要写的文件夹是否有读写权限, 如果有, 则直接下载